### PR TITLE
count_sort mixes new and free

### DIFF
--- a/sorting/count_sort.cpp
+++ b/sorting/count_sort.cpp
@@ -22,7 +22,7 @@ int count_sort(datatype *A,datatype N,datatype max_){
             j++;
         }
     }
-    free(B);
+    delete [] B;
     return 0;
 
 }


### PR DESCRIPTION
You should not use free() to release memory that has been allocated with 'new'.