### PR TITLE
merge_sort memory leak.

### DIFF
--- a/sorting/merge_sort.cpp
+++ b/sorting/merge_sort.cpp
@@ -50,6 +50,7 @@ int merge_sort(datatype *A,datatype N){
     datatype *B;      //Helping array
     B = (datatype *) malloc(N*sizeof(datatype));
     sort_(A,B,0,N-1);
+    free(B);
     return 0;
 }
 


### PR DESCRIPTION
You should not use free() to release memory that has been allocated with 'new'.